### PR TITLE
Update anchor.js

### DIFF
--- a/packages/block-editor/src/hooks/anchor.js
+++ b/packages/block-editor/src/hooks/anchor.js
@@ -77,7 +77,7 @@ export const withInspectorControl = createHigherOrderComponent(
 								help={
 									<>
 										{ __(
-											'Enter a word or two — without spaces — to make a unique web address just for this heading, called an “anchor.” Then, you’ll be able to link directly to this section of your page.'
+											'Enter a word or two — without spaces — to make a unique web address just for this block, called an “anchor.” Then, you’ll be able to link directly to this section of your page.'
 										) }
 
 										<ExternalLink


### PR DESCRIPTION
Fixes ##28296

## Description
The HTML Anchor field is described as follows: "Enter a word or two — without spaces — to make a unique web address just for this heading, called an “anchor.” Then, you’ll be able to link directly to this section of your page."
Link to string on translate: https://translate.wordpress.org/projects/wp/dev/fr/default/?filters%5Bstatus%5D=either&filters%5Boriginal_id%5D=8431365&filters%5Btranslation_id%5D=66590331

The problem lies in the use of the term "heading" which is inappropriate since it is possible to define an HTML anchor on all the blocks (with a few exceptions) whereas the term "heading" refers only to the Heading block.

I propose to simply replace the term "heading" by the term "block" in these string.
"Enter a word or two — without spaces — to make a unique web address just for this block, called an “anchor.” Then, you’ll be able to link directly to this section of your page."

Thus there will be no more inaccuracy on the element to which the anchor is applied.

The line 80 has been edited, I replaced "heading" by "block".

I hope I made the modification correctly.


